### PR TITLE
Load vanilla pipe's max_underground_distance later to allow time for other mods to change it

### DIFF
--- a/compatibility/underground-pipe-length.lua
+++ b/compatibility/underground-pipe-length.lua
@@ -1,0 +1,74 @@
+local pipeData = require("prototypes.pipe-definitions")
+
+local SPACE_DISTANCE = 14
+
+local base_ug_distance = util.table.deepcopy(data.raw["pipe-to-ground"]["pipe-to-ground"].fluid_box.pipe_connections[2].max_underground_distance)
+local space_pipe_area = 100
+
+if mods["space-exploration"] then
+  space_pipe_area = data.raw["pipe"]["se-space-pipe"].fluid_box.base_area
+end
+
+local function update_underground_distances(entity, newDistance)
+  log("Updating " .. entity.name .. " to have fluid connections at distance " .. newDistance)
+  for _,connection in pairs(entity.fluid_box.pipe_connections) do
+    if connection.max_underground_distance then
+      connection.max_underground_distance = newDistance
+    end
+  end
+end
+
+for types, sets in pairs(pipeData.pipeNames) do
+  for _ , datas in pairs(sets) do
+    for variants, directions in pairs(datas.variant) do
+      for levelsS , levelsN in pairs(pipeData.levels) do
+        local currentName
+        local newDistance = base_ug_distance + 1
+        if levelsS == "1" then
+          currentName = types .. variants ..  "pipe"
+        elseif levelsS == "space" then
+          currentName = types .. variants ..  "space-pipe"
+          newDistance = SPACE_DISTANCE + 2
+        else
+          currentName = types .. variants .. "t" .. levelsS .. "-pipe"
+          newDistance = newDistance * levelsN
+        end
+
+        local pipe = data.raw["pipe-to-ground"][currentName]
+        update_underground_distances(pipe, newDistance)
+        if levelsS == "space" then
+          pipe.fluid_box.base_area = space_pipe_area
+        end
+      end
+    end
+  end
+end
+
+for name, properties in pairs(pipeData.undergroundNames) do
+  for levelsS , levelsN in pairs(pipeData.levels) do
+    local currentName
+    local newDistance = base_ug_distance + 1
+    if levelsS == "1" then
+      currentName = name .. "-pipe"
+    elseif levelsS == "space" then
+      currentName = name .. "-space-pipe"
+      newDistance = SPACE_DISTANCE
+    else
+      currentName = name .. "-t" .. levelsS .. "-pipe"
+      newDistance = newDistance * levelsN
+    end
+
+    local pipe = data.raw["pipe-to-ground"][currentName]
+    update_underground_distances(pipe, newDistance)
+    if levelsS == "space" then
+      pipe.fluid_box.base_area = space_pipe_area
+    end
+  end
+end
+
+update_underground_distances(data.raw["pipe"]["4-to-4-pipe"], base_ug_distance + 1)
+update_underground_distances(data.raw["pump"]["underground-mini-pump"], base_ug_distance * 3 + 1)
+
+if mods["space-exploration"] then
+  update_underground_distances(data.raw["pump"]["underground-space-pump"], SPACE_DISTANCE + 2)
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,1 @@
+require("compatibility.underground-pipe-length")

--- a/info.json
+++ b/info.json
@@ -12,6 +12,7 @@
     "(?) Dectorio",
     "stdlib >= 1.4.2",
     "(?) space-exploration",
+    "(?) Krastorio",
     "(?) boblogistics"
   ]
 }

--- a/prototypes/entities/pipes-to-ground.lua
+++ b/prototypes/entities/pipes-to-ground.lua
@@ -1,3 +1,5 @@
+local pipeData = require("prototypes.pipe-definitions")
+
 local north = {position = {0, -1}}
 local south = {position = {0, 1}}
 local west = {position = {-1, 0}}
@@ -20,7 +22,8 @@ local direction_table = {
   ['NSE'] = {north, south, east},
   ['NSEW'] = {north, south, east, west}
 }
-local base_ug_distance = util.table.deepcopy(data.raw["pipe-to-ground"]["pipe-to-ground"].fluid_box.pipe_connections[2].max_underground_distance)
+
+local base_ug_distance = 10
 local function build_connections_table(directions, level)
   local connections_table = {
     { position = {0, -1} },
@@ -38,78 +41,6 @@ local function build_connections_table(directions, level)
     }
   end
   return connections_table
-end
-
-local namesTable = {
-  ["one-to-one"] = {
-    {
-      icon = "one-to-one",
-      mine_and_place = "-forward",
-      variant = {
-      ["-forward-"] = "S",
-      ["-left-"] = "E",
-      ["-reverse-"] = "N",
-      ["-right-"] = "W"
-      }
-    }
-  },
-  ["one-to-two"] = {
-    {
-      icon = "one-to-two-parallel",
-      mine_and_place = "-perpendicular",
-      variant = {
-      ["-perpendicular-"] = "EW",
-      ["-parallel-"] = "NS",
-      ["-perpendicular-secondary-"] = "EW",
-      ["-parallel-secondary-"] = "NS",
-      ["-L-FL-"] = "SE",
-      ["-L-FR-"] = "SW",
-      ["-L-RR-"] = "NW",
-      ["-L-RL-"] = "NE"
-      }
-    },
-    --[[{
-      icon = "one-to-two-L",
-      mine_and_place = "-L-FL",
-      variant = {
-        ["-L-FL-"] = "SE",
-        ["-L-FR-"] = "SW",
-        ["-L-RR-"] = "NW",
-        ["-L-RL-"] = "NE"
-      }
-    }]]--
-  },
-  ["one-to-three"] = {
-    {
-      icon = "one-to-three",
-      mine_and_place = "-forward",
-      variant = {
-      ["-forward-"] = "SEW",
-      ["-left-"] = "NSE",
-      ["-reverse-"] = "NEW",
-      ["-right-"] = "NSW"
-      }
-    }
-  },
-  ["one-to-four"] = {
-    {
-      icon = "one-to-four",
-      mine_and_place = "",
-      variant = {
-        ["-"] = "NSEW"
-      }
-    }
-  }
-}
-
-local levelsTable = {
-  ["1"] = 1,
-  ["2"] = 2,
-  ["3"] = 3
-}
-
-if mods["space-exploration"] then
-  levelsTable["space"] = 4
 end
 
 local file_path = "__underground-pipe-pack__/graphics/entity/level-"
@@ -181,10 +112,10 @@ end
 
 
 local pipes ={}
-for types, sets in pairs(namesTable) do
+for types, sets in pairs(pipeData.pipeNames) do
   for _ , datas in pairs(sets) do
     for variants, directions in pairs(datas.variant) do
-      for levelsS , levelsN in pairs(levelsTable) do
+      for levelsS , levelsN in pairs(pipeData.levels) do
         local currentPipe = util.table.deepcopy(data.raw["pipe-to-ground"]["pipe-to-ground"])
         if levelsS == "1" then
           currentPipe.name = types .. variants ..  "pipe"

--- a/prototypes/entities/underground-buildings.lua
+++ b/prototypes/entities/underground-buildings.lua
@@ -1,5 +1,5 @@
 require "circuit_connector_definitions"
-local base_ug_distance = util.table.deepcopy(data.raw['pipe-to-ground']['pipe-to-ground'].fluid_box.pipe_connections[2].max_underground_distance)
+local base_ug_distance = 10
 
 local blue_color = {0, 0.831, 1, 0.5}
 data:extend(
@@ -289,7 +289,7 @@ if mods["space-exploration"] then
   local space_pump = util.table.deepcopy(data.raw['pump']['underground-mini-pump'])
   space_pump.name = "underground-space-pump"
   for _, connection in pairs(space_pump.fluid_box.pipe_connections) do
-    connection.max_underground_distance = 16
+    connection.max_underground_distance = base_ug_distance
   end
   space_pump.minable.result = "underground-space-pump"
   space_pump.collision_mask = afh_space_only

--- a/prototypes/entities/underground-pipes.lua
+++ b/prototypes/entities/underground-pipes.lua
@@ -1,3 +1,5 @@
+local pipeData = require("prototypes.pipe-definitions")
+
 local Color = require('__stdlib__/stdlib/utils/color')
 
 local north = {position = {0, -1}}
@@ -11,13 +13,13 @@ local direction_table = {
     ['ESW'] = {east, south, west},
     ['NSEW'] = {north, south, east, west}
 }
-local base_ug_distance = util.table.deepcopy(data.raw["pipe-to-ground"]["pipe-to-ground"].fluid_box.pipe_connections[2].max_underground_distance)
+local base_ug_distance = 10
 local function build_connections_table(directions, level)
   local connections_table = {}
   local max_distance
   for _, datas in pairs(direction_table[directions]) do
     if level == "space" then
-      max_distance = 14
+      max_distance = base_ug_distance
     else
       max_distance = (base_ug_distance + 1) * level
     end
@@ -29,46 +31,7 @@ local function build_connections_table(directions, level)
   return connections_table
 end
 
-local names_table = {
-    ["underground-i"] = {
-        directions = 'NS',
-        picture_variants = {
-            up = 'NS',
-            right = 'EW',
-            down = 'NS',
-            left = 'EW'
-        }
-    },
-    ["underground-L"] = {
-        directions = 'ES',
-        picture_variants = {
-            up = 'ES',
-            down = 'NW',
-            right = 'SW',
-            left = 'NE'
-        }
-    },
-    ["underground-t"] = {
-        directions = 'ESW',
-        picture_variants = {
-            up = 'ESW',
-            right = 'NSW',
-            down = 'NEW',
-            left = 'NES'
-        }
-    },
-    ["underground-cross"] = {
-        directions = 'NSEW',
-        picture_variants = {
-            up = 'NESW',
-            down = 'NESW',
-            left = 'NESW',
-            right = 'NESW'
-        }
-    },
-}
-
-local levels_table = {
+local colors_table = {
     [1] = Color.from_rgb(255,191,0,255/2),
     [2] = Color.from_rgb(227,38,45,255/2),
     [3] = Color.from_rgb(38,173,227,255/2),
@@ -77,7 +40,7 @@ local levels_table = {
 }
 
 if mods["space-exploration"] then
-    levels_table["space"] = Color.from_rgb(255,255,255,255/2)
+    colors_table["space"] = Color.from_rgb(255,255,255,255/2)
 end
 
 local file_path = "__underground-pipe-pack__/graphics/entity/underground-cap/"
@@ -172,27 +135,27 @@ local function build_picture_table(variants, color)
 end
 
 local pipes = {}
-for name, properties in pairs(names_table) do
-    for level, color in pairs(levels_table) do
+for name, properties in pairs(pipeData.undergroundNames) do
+    for levelsS, levelsN in pairs(pipeData.levels) do
         local current_pipe = util.table.deepcopy(data.raw["pipe-to-ground"]["pipe-to-ground"])
-        if level == 1 then
+        if levelsS == "1" then
             current_pipe.name = name .. "-pipe"
             current_pipe.minable.result = name .. "-pipe"
-        elseif level == "space" then
+        elseif levelsS == "space" then
             current_pipe.name = name .. "-space-pipe"
             current_pipe.minable.result = name .. "-space-pipe"
         else
-            current_pipe.name = name .. "-t" .. level .. "-pipe"
-            current_pipe.minable.result = name .. "-t" .. level .. "-pipe"
+            current_pipe.name = name .. "-t" .. levelsS .. "-pipe"
+            current_pipe.minable.result = name .. "-t" .. levelsS .. "-pipe"
         end
 
-        if level == "space" then
+        if levelsS == "space" then
             current_pipe.collision_mask = afh_space_only
             current_pipe.icon = "__underground-pipe-pack__/graphics/icons/space-exploration-compat/" .. name .. ".png"
             current_pipe.se_allow_in_space = true
         else
             current_pipe.collision_mask = afh_ground_only
-            current_pipe.icon = "__underground-pipe-pack__/graphics/icons/" .. name .. "-t" .. level .. ".png"
+            current_pipe.icon = "__underground-pipe-pack__/graphics/icons/" .. name .. "-t" .. levelsS .. ".png"
             current_pipe.se_allow_in_space = false
         end
 
@@ -200,13 +163,13 @@ for name, properties in pairs(names_table) do
         current_pipe.selection_priority = 51
 
         local fluid_box = util.table.deepcopy(current_pipe.fluid_box)
-        fluid_box.pipe_connections = build_connections_table(properties.directions, level)
+        fluid_box.pipe_connections = build_connections_table(properties.directions, levelsS)
         fluid_box.pipe_covers = nil
         current_pipe.fluid_box = fluid_box
 
         current_pipe.fast_replaceable_group = "pipe-to-ground"
         current_pipe.next_upgrade = nil
-        current_pipe.pictures = build_picture_table(properties.picture_variants, color)
+        current_pipe.pictures = build_picture_table(properties.picture_variants, colors_table[levelsN])
         current_pipe.draw_fluid_icon_override = true
         pipes[#pipes + 1] = current_pipe
     end

--- a/prototypes/pipe-definitions.lua
+++ b/prototypes/pipe-definitions.lua
@@ -1,0 +1,117 @@
+local pipeNamesTable = {
+  ["one-to-one"] = {
+    {
+      icon = "one-to-one",
+      mine_and_place = "-forward",
+      variant = {
+      ["-forward-"] = "S",
+      ["-left-"] = "E",
+      ["-reverse-"] = "N",
+      ["-right-"] = "W"
+      }
+    }
+  },
+  ["one-to-two"] = {
+    {
+      icon = "one-to-two-parallel",
+      mine_and_place = "-perpendicular",
+      variant = {
+      ["-perpendicular-"] = "EW",
+      ["-parallel-"] = "NS",
+      ["-perpendicular-secondary-"] = "EW",
+      ["-parallel-secondary-"] = "NS",
+      ["-L-FL-"] = "SE",
+      ["-L-FR-"] = "SW",
+      ["-L-RR-"] = "NW",
+      ["-L-RL-"] = "NE"
+      }
+    },
+    --[[{
+      icon = "one-to-two-L",
+      mine_and_place = "-L-FL",
+      variant = {
+        ["-L-FL-"] = "SE",
+        ["-L-FR-"] = "SW",
+        ["-L-RR-"] = "NW",
+        ["-L-RL-"] = "NE"
+      }
+    }]]--
+  },
+  ["one-to-three"] = {
+    {
+      icon = "one-to-three",
+      mine_and_place = "-forward",
+      variant = {
+      ["-forward-"] = "SEW",
+      ["-left-"] = "NSE",
+      ["-reverse-"] = "NEW",
+      ["-right-"] = "NSW"
+      }
+    }
+  },
+  ["one-to-four"] = {
+    {
+      icon = "one-to-four",
+      mine_and_place = "",
+      variant = {
+        ["-"] = "NSEW"
+      }
+    }
+  }
+}
+
+local undergroundNamesTable = {
+    ["underground-i"] = {
+        directions = 'NS',
+        picture_variants = {
+            up = 'NS',
+            right = 'EW',
+            down = 'NS',
+            left = 'EW'
+        }
+    },
+    ["underground-L"] = {
+        directions = 'ES',
+        picture_variants = {
+            up = 'ES',
+            down = 'NW',
+            right = 'SW',
+            left = 'NE'
+        }
+    },
+    ["underground-t"] = {
+        directions = 'ESW',
+        picture_variants = {
+            up = 'ESW',
+            right = 'NSW',
+            down = 'NEW',
+            left = 'NES'
+        }
+    },
+    ["underground-cross"] = {
+        directions = 'NSEW',
+        picture_variants = {
+            up = 'NESW',
+            down = 'NESW',
+            left = 'NESW',
+            right = 'NESW'
+        }
+    },
+}
+
+-- Table gets built in reverse so that we can use the current pipe tier for the next pipes next_upgrade
+local levelsTable = {}
+
+if mods["space-exploration"] then
+  levelsTable["space"] = 4
+end
+
+levelsTable["3"] = 3
+levelsTable["2"] = 2
+levelsTable["1"] = 1
+
+return {
+  pipeNames = pipeNamesTable,
+  undergroundNames = undergroundNamesTable,
+  levels = levelsTable,
+}


### PR DESCRIPTION
See: https://mods.factorio.com/mod/underground-pipe-pack/discussion/62ee0e975ea6069cadafa23e

This mod was reading the vanilla pipe's max underground distance inside of data.lua, whereas krastorio2 was updating it inside of data-updates.lua, meaning it would always happen later regardless of dependencies or load order. This change makes it so that the vanilla pipe's underground distance is read during data-updates.lua as well and then updates the pipes there. This correctly sets the pipe length to 21/41/61 based on krastorio's underground pipe length of 20, and it will allow for more compatibility with other mods that change the underground distance. 

I could have done it with data-final-fixes.lua to be even more sure of that but that was breaking the [show max underground distance mod](https://mods.factorio.com/mod/show-max-underground-distance) because of when it reads in the max underground distance of all pipes.

I also made a small tweak to the space pipes. Space exploration has a setting to change the space pipes' volumes. This updates the space underground pipes added by this mod to be the same.